### PR TITLE
feat(project): add CTA buttons for repo & demo links

### DIFF
--- a/src/components/project/Project.css
+++ b/src/components/project/Project.css
@@ -125,3 +125,32 @@
     transform: translateX(0);
   }
 }
+
+.project-info-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.btn-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: 9999px;
+  background: #0be779; /* tu verde */
+  color: #0b1424;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform .15s ease, filter .15s ease;
+}
+
+.btn-cta:hover { transform: translateY(-1px); filter: brightness(1.05); }
+
+.btn-cta.outline {
+  background: transparent;
+  border: 2px solid #0be779;
+  color: #fff;
+}
+
+.btn-icon img { width: 22px; height: 22px; }

--- a/src/components/project/Project.js
+++ b/src/components/project/Project.js
@@ -3,7 +3,7 @@ import './Project.css'
 import { useTranslation } from 'react-i18next'
 
 const Project = ({ project, type }) => {
-  const { i18n } = useTranslation()
+  const { t, i18n } = useTranslation()
   const lang = i18n.language
   const descText = typeof project.description === 'object'
     ? project.description[lang]
@@ -43,13 +43,44 @@ const Project = ({ project, type }) => {
                 </div>
               ))}
             </div>
-            {project.link && (
-              <div className="project-info-right">
-                <a href={project.link} target="_blank" rel="noopener noreferrer">
+            <div className="project-info-right">
+              {project.code && (
+                <a
+                  className="btn-cta"
+                  href={project.code}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Repositorio en GitHub"
+                  title="Repositorio en GitHub"
+                >
+                  <span>{t('projects_repo')}</span>
+                </a>
+              )}
+
+              {project.demo && (
+                <a
+                  className="btn-cta outline"
+                  href={project.demo}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Demo"
+                  title="Demo"
+                >
+                  <span>{t('projects_demo')}</span>
+                </a>
+              )}
+
+              {!project.repo && !project.code && project.demo && (
+                <a
+                  className="btn-icon"
+                  href={project.repo}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   <img src={require('../../images/next.png')} alt="next" />
                 </a>
-              </div>
-            )}
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/data/featured_projects.json
+++ b/src/data/featured_projects.json
@@ -2,7 +2,9 @@
   "featured_projects": [
     {
       "name": "Star Wars GraphQL API",
-      "link": "https://github.com/Jeiikot/starwars-graphql-django",
+      "repo": "https://github.com/Jeiikot/starwars-graphql-django",
+      "code": "https://github.com/Jeiikot/starwars-graphql-django/tree/main",
+      "demo": "https://starwars-graphql-django.onrender.com/graphql/",
       "description": {
         "es": "API GraphQL construida con Django y Graphene para consultar, crear y relacionar personajes, películas y planetas del universo Star Wars. Desarrollada como prueba técnica para demostrar habilidades avanzadas en Django y GraphQL.",
         "en": "GraphQL API built with Django and Graphene to query, create, and relate Star Wars characters, movies, and planets. Developed as a technical challenge to demonstrate Django and GraphQL skills."

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -58,5 +58,8 @@
   "skills_aws": "AWS",
   "skills_docker": "Docker",
 
+  "projects_repo": "Repository",
+  "projects_demo": "Demo",
+
   "footer_message": "¡Gracias por visitar!"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -57,5 +57,8 @@
   "skills_aws": "AWS",
   "skills_docker": "Docker",
 
+  "projects_repo": "Repositorio",
+  "projects_demo": "Demo",
+
   "footer_message": "Thanks for visiting!"
 }


### PR DESCRIPTION
Add conditional “Repository” and “Demo” call-to-action buttons to each Project card:

* **UI/Styles** – introduce , , and variants in  for pill styling and hover feedback.
* **Component logic** – update  to use  from , render buttons when , , or  are present, and keep fallback icon support.
* **Data** – extend  with , , and  fields.
* **i18n** – add  and  keys to both  and .

These changes give visitors one-click access to source code and live demos, improving discoverability and user experience.