### PR TITLE
fix(contact): clean unused imports & correct TextField syntax

### DIFF
--- a/src/components/contact/Contact.js
+++ b/src/components/contact/Contact.js
@@ -5,9 +5,6 @@ import { Bounce } from 'react-reveal'
 import ContactForm from '../contactForm/ContactForm'
 import linkedin from '../../images/social/linkedin.png'
 import github from '../../images/social/github.png'
-import instagram from '../../images/social/instagram.png'
-import twitter from '../../images/social/twitter.png'
-import Stackoverflow from '../../images/social/stackoverflow.png'
 import { useTranslation } from 'react-i18next'
 
 const Contact = () => {

--- a/src/components/contactForm/ContactForm.js
+++ b/src/components/contactForm/ContactForm.js
@@ -107,7 +107,7 @@ const ContactForm = () => {
         action="https://formspree.io/f/mqalbaad"
         method="POST"
       >
-        <TextField<
+        <TextField
           className={classes.email}
           type="email"
           name="email"


### PR DESCRIPTION
Removed unused social-media icon imports (instagram, twitter, Stackoverflow) from Contact.js, reducing dead code and bundle size. Also dropped the stray generic parameter from <TextField> in ContactForm.js to match MUI’s API and resolve compilation/lint errors.